### PR TITLE
Stable jkphl/dom-factory support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
     },
     "require": {
         "php": ">=5.5",
-        "jkphl/dom-factory": "^0.1.2"
+        "jkphl/dom-factory": "^0.1.2 || ^1"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
     },
     "require": {
         "php": ">=5.5",
-        "jkphl/dom-factory": "^0.1.2 || ^1"
+        "jkphl/dom-factory": "^1"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
rdfa-lite-microdata only support dom-factory versions < 1 now. Should also support the stable versions 1 of dom-factory